### PR TITLE
Add Update/Delete booking to calendar

### DIFF
--- a/dbinit.sql
+++ b/dbinit.sql
@@ -23,7 +23,7 @@ CREATE TABLE room (
 
 CREATE TABLE family (
     family_id       SERIAL      PRIMARY KEY,
-    family_name     TEXT        UNIQUE,
+    family_name     TEXT        
     parent_one      INT         REFERENCES users (user_id),
     parent_two      INT         REFERENCES users (user_id),
     children		INT

--- a/dbinit.sql
+++ b/dbinit.sql
@@ -23,7 +23,7 @@ CREATE TABLE room (
 
 CREATE TABLE family (
     family_id       SERIAL      PRIMARY KEY,
-    family_name     TEXT        
+    family_name     TEXT,        
     parent_one      INT         REFERENCES users (user_id),
     parent_two      INT         REFERENCES users (user_id),
     children		INT

--- a/events.go
+++ b/events.go
@@ -128,7 +128,7 @@ func unbookBooking(w http.ResponseWriter, r *http.Request, bid int) {
 		return
 	}
 	enc := json.NewEncoder(w)
-	ret := RetData{Msg: "Sucessfully deleted booking!"}
+	ret := RetData{Msg: "Sucessfully deleted booking!" + "\nBooking ID was: " + strconv.Itoa(bid)}
 	enc.Encode(ret)
 }
 

--- a/events.go
+++ b/events.go
@@ -77,13 +77,14 @@ func bookBooking(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Get family_id and user_id from request soemhow for dis
-	fid := 7357
-	uid := 7555
+	fid := 1 // placeholder id for entry in DB
+	uid := 1 // parent with uid 1 is in family 1 for now
 
 	q := `INSERT INTO booking (block_id, family_id, user_id, 
 			booking_start, booking_end) 
 			VALUES ($1, $2, $3, $4, $5)
 			RETURNING booking_id`
+
 	var book_id int
 	err = db.QueryRow(q, id, fid, uid, ev["start"], ev["end"]).Scan(&book_id)
 	if err != nil {

--- a/router.go
+++ b/router.go
@@ -50,8 +50,7 @@ func createRouter() (*mux.Router, error) {
 	s.HandleFunc("/admin/calendar/setup/", undoSetup).Methods("DELETE")
 	/* Events JSON routes for scheduler system */
 	s.HandleFunc("/events", getEvents).Methods("GET")
-	s.HandleFunc("/events", updateEvent).Methods("POST") // Changes made to schedule,  update block
-
+	s.HandleFunc("/events/{target}", eventPostHandler).Methods("POST")
 	v := r.PathPrefix("/app").Subrouter()
 	// need redirect for '/' -> '/dashboard'
 	v.HandleFunc("/dashboard/", renderDashboard).Methods("GET")

--- a/views/calendar.gohtml
+++ b/views/calendar.gohtml
@@ -47,9 +47,10 @@
         function requestBooking(event, jsEvent, view) {
             // Block info for booking
             booking_json = JSON.stringify({
-                id:   event.id,
+                id:         event.id,
                 start:      event.start,
                 end:        event.end,
+                bookingIds: event.bookingIds
             });
 
             // Make ajax POST request with booking request or request bookign delete if already booked
@@ -61,10 +62,10 @@
                 dataType:'json',
                 success: function(data) {  // We expect the server to return json data with a msg field
                     alert(data.msg);
-                    event.bookings++;
+                    $('#calendar').fullCalendar('refetchEvents')
                 },
                 error: function(xhr, ajaxOptions, thrownError) {
-                    alert("Request failed: " + xhr + "\n" + thrownError);
+                    alert("Request failed: " + thrownError);
                 }
             });
         }
@@ -73,7 +74,7 @@
         function renderEvent(event, element) {
             // Create speechbubble which displays info about event
             $(element).qtip({
-                content: event.note + "<br>Attending: " + event.bookings
+                content: event.note + "<br>Attending: " + event.bookingCount
             });
         }
 
@@ -115,7 +116,7 @@
                     storeChangesToEvent(ev, delta, revertFunc, jsEvent, ui, view);
                 },
                 eventClick: function(event, jsEvent, view) {
-                    if (confirm("Confirm booking?")) {
+                    if (confirm("Confirm booking change?")) {
                         requestBooking(event, jsEvent, view)
                     }
                 }

--- a/views/calendar.gohtml
+++ b/views/calendar.gohtml
@@ -1,16 +1,57 @@
 <!DOCTYPE html>  
-<html lang="en">  
-  <head>
-    <!-- fullCalendar dependencies -->
+<html lang="en"> 
+  <head> 
+    <!-- fullCalendar & scheduler dependencies -->
     <link rel='stylesheet' type='text/css' href='/views/fullcalendar/fullcalendar.css'/>
+    <link rel='stylesheet' type='text/css' href='http://cdn.jsdelivr.net/qtip2/3.0.3/jquery.qtip.min.css'/>
+    <link rel="stylesheet" type='text/css' href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <script type="text/javascript" src='/views/fullcalendar/lib/jquery.min.js'></script>
     <script type="text/javascript" src='/views/fullcalendar/lib/moment.min.js'></script>
+    <script type="text/javascript" src='http://cdn.jsdelivr.net/qtip2/3.0.3/jquery.qtip.min.js'></script>
     <script type="text/javascript" src='/views/fullcalendar/fullcalendar.js'></script>
-    <link rel="stylesheet" type='text/css' href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+
+    <!-- Full Calendar Configuration Script -->
     <script type="text/javascript">
+        // Callback function for drag/drops and resizes of existing events
+        // Note: We dont want this to be populated if we aren't admin.
+        function storeChangesToEvent(event, delta, revertFunc, jsEvent, ui, view) {
+            // Extract block data required for updating on server
+            event_json = JSON.stringify({
+                id: event.id,
+                start: event.start,
+                end:   event.end,
+                modifier: event.value
+            });
+            // Make ajax post request with updated event data
+            $.ajax({
+                url: '/api/v1/events',
+                type: 'POST',
+                contentType:'json',
+                data: event_json,
+                dataType:'json',
+                success: function(data) { 
+                    alert("Event updated successfully!");
+                },
+                error: function(xhr, ajaxOptions, thrownError) {
+                    revertFunc();
+                    alert("Request failed: " + xhr + "\n" + thrownError);
+                }
+            });
+        }
+        
+        // Determines the event rendering
+        function renderEvent(event, element) {
+            // Create speechbubble which displays info about event
+            $(element).qtip({
+                content: event.note + "<br>Attending: " + event.bookings
+            });
+        }
+
         $(document).ready(function() {
             // page is now ready, initialize the calendar...
             $('#calendar').fullCalendar({
+                // Education use (both now and if deployed!)
+                schedulerLicenseKey: "CC-Attribution-NonCommercial-NoDerivatives",
                 weekends: false,
                 header: {
                     left: 'today',
@@ -21,6 +62,9 @@
                 allDayDefault: false,        // blocks are not all-day unless specified
                 themeSystem: "bootstrap3",
                 editable: true,                 // Need to use templating engine to change bool based on user's role
+                eventRender: function(event, element) { 
+                    renderEvent(event, element)
+                },
                 // DOM-Event handling for Calendar Eventblocks (why do js people suck at naming)
                 eventOverlap: function(stillEvent, movingEvent) {      // Event blocks in different rooms may overlap, events in same room may not
                     // Note: events may overlap on import; moving events will not be allowed to over lap
@@ -30,31 +74,16 @@
                     }
                     return true;
                 },
+                // When and event is drag/dropped to new day/time --> updates db & stuff
+                // revertFunc is called should our update request fail
+                eventDrop: function(ev, delta, revertFunc, jsEvent, ui, view) {
+                    storeChangesToEvent(ev, delta, revertFunc, jsEvent, ui, view);
+                },
                 // When an event is resized (post duration change) it will callback the function
                 // revertFunc is fullCalendar function which reverts the display should the request fail
-                eventResize: function(event, delta, revertFunc, jsEvent, ui, view) {
-                    // Extract block data required for updating on server
-                    event_json = JSON.stringify({
-                       id: event.id,
-                       start: event.start,
-                       end:   event.end
-                    });
-                    // Make ajax post request with updated event data
-                    $.ajax({
-                        url: '/api/v1/events',
-                        type: 'POST',
-                        contentType:'json',
-                        data: event_json,
-                        dataType:'json',
-                        success: function(data) { 
-                            alert("Event updated successfully!");
-                        },
-                        error: function(xhr, ajaxOptions, thrownError) {
-                            revertFunc();
-                            alert("Request failed: " + xhr + "\n" + thrownError);
-                        }
-                    });
-                 }
+                eventResize: function(ev, delta, revertFunc, jsEvent, ui, view) {
+                    storeChangesToEvent(ev, delta, revertFunc, jsEvent, ui, view);
+                }
             })
         });
     </script>

--- a/views/calendar.gohtml
+++ b/views/calendar.gohtml
@@ -47,7 +47,7 @@
         function requestBooking(event, jsEvent, view) {
             // Block info for booking
             booking_json = JSON.stringify({
-                block_id:   event.id,
+                id:   event.id,
                 start:      event.start,
                 end:        event.end,
             });

--- a/views/calendar.gohtml
+++ b/views/calendar.gohtml
@@ -14,6 +14,7 @@
     <script type="text/javascript">
         // Callback function for drag/drops and resizes of existing events
         // Note: We dont want this to be populated if we aren't admin.
+        // post-demo will refactor this out into templates populated differently based on the role of the user
         function storeChangesToEvent(event, delta, revertFunc, jsEvent, ui, view) {
             // Extract block data required for updating on server
             event_json = JSON.stringify({
@@ -24,13 +25,13 @@
             });
             // Make ajax post request with updated event data
             $.ajax({
-                url: '/api/v1/events',
+                url: '/api/v1/events/update',
                 type: 'POST',
                 contentType:'json',
                 data: event_json,
                 dataType:'json',
                 success: function(data) { 
-                    alert("Event updated successfully!");
+                    alert(data.msg);
                 },
                 error: function(xhr, ajaxOptions, thrownError) {
                     revertFunc();
@@ -39,6 +40,35 @@
             });
         }
         
+        // This function will send a booking request to the server
+        // Like the updateEvent function, post-demo I will refactor this out
+        // and have the templates populate based on role. Additional auth checks
+        // server side to ensure correct user/role and such should still take place
+        function requestBooking(event, jsEvent, view) {
+            // Block info for booking
+            booking_json = JSON.stringify({
+                block_id:   event.id,
+                start:      event.start,
+                end:        event.end,
+            });
+
+            // Make ajax POST request with booking request or request bookign delete if already booked
+            $.ajax({
+                url: '/api/v1/events/book',
+                type: 'POST',
+                contentType:'json',
+                data: booking_json,
+                dataType:'json',
+                success: function(data) {  // We expect the server to return json data with a msg field
+                    alert(data.msg);
+                    event.bookings++;
+                },
+                error: function(xhr, ajaxOptions, thrownError) {
+                    alert("Request failed: " + xhr + "\n" + thrownError);
+                }
+            });
+        }
+
         // Determines the event rendering
         function renderEvent(event, element) {
             // Create speechbubble which displays info about event
@@ -83,6 +113,11 @@
                 // revertFunc is fullCalendar function which reverts the display should the request fail
                 eventResize: function(ev, delta, revertFunc, jsEvent, ui, view) {
                     storeChangesToEvent(ev, delta, revertFunc, jsEvent, ui, view);
+                },
+                eventClick: function(event, jsEvent, view) {
+                    if (confirm("Confirm booking?")) {
+                        requestBooking(event, jsEvent, view)
+                    }
                 }
             })
         });


### PR DESCRIPTION
Well sort of... see commit history for more details.
Main things to be implemented/changed:
-> family and user id for bookings is hard coded as 1,1; need to extract this info from the requesting party somehow (rina you may know how to do this?)
-> Quite a bit of duplicated(or close to duplicated) code that I/We can refactor after our demo
-> Booking changes induce a full refetch from the events source, which will not be sweet on a year long data set. Need to find way to update only the event that changed, which is not immediately apparent. If it turns out that we cannot refetch the single event, we can constrain the refetch operation to only fetch events within the view (month, week, day, etc.) which will lessen the burden. Again, for the demo just having the full functionality is the goal; we can refine this stuff out during the next sprint.
-> Need to migrate towards single-page application, where dashboard/calendar get swapped out of a static template. Calendar itself needs to be templated based on user role (facilitators get to book/unbook themselves; admins get ability to resize/move/add/delete events). As well as for clarity (separate js script configuring calendar and its actions from the html page mainly).
   >> On that note: need to give admins add/delete event functionality (add will probably be a modal + form? and delete I think will be a clickEvent) 



