### PR TITLE
Add Gauges+Chart to Dashboard

### DIFF
--- a/booking.go
+++ b/booking.go
@@ -44,7 +44,7 @@ func (b *bookingBlock) updateBooking() error {
 		return err
 	}
 	if count != 1 {
-		err = errors.New("Booking not updated")
+		err = errors.New("booking not updated")
 		return err
 	}
 	return nil
@@ -63,7 +63,7 @@ func (b *bookingBlock) deleteBooking() error {
 		return err
 	}
 	if count != 1 {
-		err = errors.New("Booking not deleted")
+		err = errors.New("booking not deleted")
 		return err
 	}
 	return nil
@@ -75,28 +75,31 @@ type Booking struct {
 	BlockID   	int       	`db:"block_id" json:"blockId"`
 	FamilyID  	int       	`db:"family_id" json:"familyId"`
 	UserID    	int       	`db:"user_id" json:"userID"`
-	Start     	time.Time 	`db:"booking_start" json:"start"`
-	End       	time.Time 	`db:"booking_end" json:"end"`
-	BlockStart 	time.Time 	`db:"block_start" json:"endBlock"`
-	BlockEnd   	time.Time 	`db:"block_end" json:"endBlock"`
+	Start 		time.Time 	`db:"block_start" json:"endBlock"`
+	End   		time.Time 	`db:"block_end" json:"endBlock"`
 	RoomID		int			`db:"room_id" json:"room_id"`
 	Modifier    int         `db:"modifier" json:"modifier"`
-	Note     	string    	`db:"note" json:"note"`
 }
 
 /* WHY */
 func getUserBookings(start time.Time, end time.Time, UID int) ([]Booking, error) {
-	/* Get all bookings in range start-now */
-	q := `SELECT * FROM booking NATURAL JOIN time_block
-			WHERE (time_block.block_id = booking.block_id
+	/* format dates for psql */
+	logger.Println("Preformat --> Start ", start, "\tEnd ", end)
+	startStr := start.Format(time.RFC3339Nano)
+	endStr:= end.Format(time.RFC3339Nano)
+	logger.Println("Formated --> Start ", startStr, "\tEnd ", endStr)
+	/* Get all bookings in range start-now  (start > block_start & end > blocK_end) */
+	q := `SELECT booking_id, block_id, family_id, user_id, block_start, block_end, room_id, modifier
+			FROM booking NATURAL JOIN time_block WHERE (
+					time_block.block_id = booking.block_id
 					AND booking.user_id = $1 
-					AND time_block.block_start >= $2 
-					AND time_block.block_end <= $3)
-			ORDER BY time_block.block_start`
+					AND $3 > time_block.block_end
+					AND $2 > time_block.block_start
+			) ORDER BY time_block.block_start`
 
 	var bookBlocks []Booking
-	err := db.Select(&bookBlocks, q, UID, start, end)
-	logger.Println("uid ", UID, "start ", start, " end ", end, "\nblocks: ", bookBlocks)
+	err := db.Select(&bookBlocks, q, UID, startStr, endStr)
+	logger.Println("Selected blocks: ", bookBlocks)
 	if err != nil {
 		logger.Println(err)
 		return nil, err

--- a/booking.go
+++ b/booking.go
@@ -68,3 +68,38 @@ func (b *bookingBlock) deleteBooking() error {
 	}
 	return nil
 }
+
+/* Joined relation of time_block and booking_block */
+type Booking struct {
+	BookingID 	int       	`db:"booking_id" json:"bookingId"`
+	BlockID   	int       	`db:"block_id" json:"blockId"`
+	FamilyID  	int       	`db:"family_id" json:"familyId"`
+	UserID    	int       	`db:"user_id" json:"userID"`
+	Start     	time.Time 	`db:"booking_start" json:"start"`
+	End       	time.Time 	`db:"booking_end" json:"end"`
+	BlockStart 	time.Time 	`db:"block_start" json:"endBlock"`
+	BlockEnd   	time.Time 	`db:"block_end" json:"endBlock"`
+	RoomID		int			`db:"room_id" json:"room_id"`
+	Modifier    int         `db:"modifier" json:"modifier"`
+	Note     	string    	`db:"note" json:"note"`
+}
+
+/* WHY */
+func getUserBookings(start time.Time, end time.Time, UID int) ([]Booking, error) {
+	/* Get all bookings in range start-now */
+	q := `SELECT * FROM booking NATURAL JOIN time_block
+			WHERE (time_block.block_id = booking.block_id
+					AND booking.user_id = $1 
+					AND time_block.block_start >= $2 
+					AND time_block.block_end <= $3)
+			ORDER BY time_block.block_start`
+
+	var bookBlocks []Booking
+	err := db.Select(&bookBlocks, q, UID, start, end)
+	logger.Println("uid ", UID, "start ", start, " end ", end, "\nblocks: ", bookBlocks)
+	if err != nil {
+		logger.Println(err)
+		return nil, err
+	}
+	return bookBlocks, nil
+}

--- a/dashboard.go
+++ b/dashboard.go
@@ -25,10 +25,10 @@ import (
   */
 func getDashData(w http.ResponseWriter, r *http.Request) {
 	UID 	:= getUID(r)
-	goal 	:= getHoursGoal(UID);
-	booked 	:= getHoursBooked(UID);
-	done 	:= getHoursDone(UID);
-	history := getHoursHistory(UID, time.Now());
+	goal 	:= getHoursGoal(UID)
+	booked 	:= getHoursBooked(UID)
+	done 	:= getHoursDone(UID)
+	history := getHoursHistory(UID, time.Now())
 
 	dd := &DashData{
 		HoursGoal: goal,
@@ -81,12 +81,13 @@ func getHoursBookingSlice(bookBlocks []Booking) float64 {
 	var duration float64
 	duration = 0.00
 	for _, bb := range bookBlocks {
-		duration += (bb.BlockEnd.Sub(bb.BlockStart).Hours() * float64(bb.Modifier))
+		duration += (bb.End.Sub(bb.Start).Hours() * float64(bb.Modifier))
 	}
 	return duration
 }
 
 /* Returns historical hours/week for past 3 months */
+/* Does not work yet. Do not expect good results yet */
 func getHoursHistory(UID int, curr time.Time) []float64 {
 	start := now.New(curr).BeginningOfWeek().AddDate(0,-3, 0) // 3 months prior to beginning of week
 	bookBlocks, err := getUserBookings(start, time.Now(), UID)
@@ -98,10 +99,10 @@ func getHoursHistory(UID int, curr time.Time) []float64 {
 	var duration float64
 	duration = 0.00
 	for i, bb := range bookBlocks {
-		duration += (bb.BlockEnd.Sub(bb.BlockStart).Hours() * float64(bb.Modifier))
-		if i != 0 && i % 5 == 0 {
+		duration = (bb.End.Sub(bb.Start).Hours() * float64(bb.Modifier))
+		if i % 5 == 0 { // Need to give this correct logic for deducing weeks
 			history = append(history, duration)
-			duration = 0 // reset to 0, week end
+			duration = 0.00 // reset to 0, week end
 		}
 	}
 	return history

--- a/dashboard.go
+++ b/dashboard.go
@@ -5,7 +5,107 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/jinzhu/now"
 )
+
+
+/*
+ * dashboard.js expects the following struct in json format/
+ */
+ type DashData struct {
+ 	 HoursGoal   	float64  	`json:"hoursGoal"`
+	 HoursBooked 	float64  	`json:"hoursBooked"`
+	 HoursDone   	float64  	`json:"hoursDone"`
+	 History     	[]float64 	`json:"history"` // historical hours completed/week for interval
+ }
+
+ /* Replacement for dashboardData
+  * which delegates most responsibility to functions
+  */
+func getDashData(w http.ResponseWriter, r *http.Request) {
+	UID 	:= getUID(r)
+	goal 	:= getHoursGoal(UID);
+	booked 	:= getHoursBooked(UID);
+	done 	:= getHoursDone(UID);
+	history := getHoursHistory(UID, time.Now());
+
+	dd := &DashData{
+		HoursGoal: goal,
+		HoursBooked: booked,
+		HoursDone: done,
+		History: history,
+	}
+	logger.Println("DASHDATA: ", dd)
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(true)
+	encoder.Encode(dd)
+}
+
+/* Get the weekly goal hours for a user */
+func getHoursGoal(UID int) float64 {
+	numKids := 0
+	q := `SELECT children FROM family
+			WHERE (parent_one = $1 OR parent_two = $1)`
+	err := db.QueryRow(q, UID).Scan(&numKids)
+	if err != nil {
+		logger.Println(err)
+		return -1
+	}
+	if numKids > 1 {
+		return 7.50 // or however much multikid families must pay to educate their kids
+	}
+	return 5.00
+}
+
+/* Get the booked hours for a user */
+func getHoursBooked(UID int) float64 {
+	bookBlocks, err := getUserBookings(now.BeginningOfWeek(), now.EndOfWeek(), UID)
+	if err != nil {
+		return -1
+	}
+	return getHoursBookingSlice(bookBlocks)
+}
+
+/* Gets hours completed this week */
+func getHoursDone(UID int) float64 {
+	bookBlocks, err := getUserBookings(now.BeginningOfWeek(), time.Now(), UID)
+	if err != nil {
+		return -1
+	}
+	return getHoursBookingSlice(bookBlocks)
+}
+
+func getHoursBookingSlice(bookBlocks []Booking) float64 {
+	logger.Println("getHoursFromBookingSlice\nBLOCKSGIVEN: ", bookBlocks)
+	var duration float64
+	duration = 0.00
+	for _, bb := range bookBlocks {
+		duration += (bb.BlockEnd.Sub(bb.BlockStart).Hours() * float64(bb.Modifier))
+	}
+	return duration
+}
+
+/* Returns historical hours/week for past 3 months */
+func getHoursHistory(UID int, curr time.Time) []float64 {
+	start := now.New(curr).BeginningOfWeek().AddDate(0,-3, 0) // 3 months prior to beginning of week
+	bookBlocks, err := getUserBookings(start, time.Now(), UID)
+	if err != nil {
+		logger.Println(err)
+		return nil
+	}
+	var history []float64
+	var duration float64
+	duration = 0.00
+	for i, bb := range bookBlocks {
+		duration += (bb.BlockEnd.Sub(bb.BlockStart).Hours() * float64(bb.Modifier))
+		if i != 0 && i % 5 == 0 {
+			history = append(history, duration)
+			duration = 0 // reset to 0, week end
+		}
+	}
+	return history
+}
 
 /*
 join family and users
@@ -46,7 +146,7 @@ func dashboardData(w http.ResponseWriter, r *http.Request) {
 	// make session stuff
 	user := getUID(r)
 	role, err := getRoleNum(r)
-	fmt.Printf("User ID found %d\n\n\n", user)
+	logger.Printf("User ID found %d\n\n\n", user)
 	start := startOfWeek(time.Now())
 	var q string
 	if role == 1 {
@@ -98,6 +198,7 @@ WHERE r.user_id = $1 AND block_start > $2 AND block_start < $3`
 	friendly.Children = bookings[0].Children
 
 	encoder := json.NewEncoder(w)
+	logger.Println("FRIENDLY:  ", friendly)
 	err = encoder.Encode(friendly)
 	if err != nil {
 		fmt.Printf("%v", err)

--- a/database/bookingdata.sql
+++ b/database/bookingdata.sql
@@ -130,3 +130,12 @@ INSERT INTO booking (block_id, user_id, family_id)
 VALUES (12, 8, 3);
 INSERT INTO booking (block_id, user_id, family_id)
 VALUES (14, 8, 3);
+
+
+--add parent to january 1 all 3 blocks room 1
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (49, 1, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (50, 1, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (51, 1, 1);

--- a/database/bookingdata.sql
+++ b/database/bookingdata.sql
@@ -1,11 +1,11 @@
 \c caraway
 --add parent to january 1 all 3 blocks room 1
-INSERT INTO booking (block_id, user_id)
-VALUES (1, 1);
-INSERT INTO booking (block_id, user_id)
-VALUES (2, 1);
-INSERT INTO booking (block_id, user_id)
-VALUES (3, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (1, 1, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (2, 1, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (3, 1, 1);
 
 --add teacher to january 2 all 3 blocks room 1
 INSERT INTO booking (block_id, user_id)
@@ -24,12 +24,12 @@ INSERT INTO booking (block_id, user_id)
 VALUES (9, 3);
 
 --add parent to january 4 all 3 blocks room 1
-INSERT INTO booking (block_id, user_id)
-VALUES (10, 1);
-INSERT INTO booking (block_id, user_id)
-VALUES (11, 1);
-INSERT INTO booking (block_id, user_id)
-VALUES (12, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (10, 1, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (11, 1, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (12, 1, 1);
 
 
 --add teacher to january 4 all 3 blocks room 1
@@ -41,92 +41,92 @@ INSERT INTO booking (block_id, user_id)
 VALUES (12, 2);
 
 --add parent to january 5 all 3 blocks room 1
-INSERT INTO booking (block_id, user_id)
-VALUES (13, 1);
-INSERT INTO booking (block_id, user_id)
-VALUES (14, 1);
-INSERT INTO booking (block_id, user_id)
-VALUES (15, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (13, 1, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (14, 1, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (15, 1, 1);
 
 --try to add same parent to january 5 all 3 blocks of room 2
-INSERT INTO booking (block_id, user_id)
-VALUES (28, 1);
-INSERT INTO booking (block_id, user_id)
-VALUES (29, 1);
-INSERT INTO booking (block_id, user_id)
-VALUES (30, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (28, 1, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (29, 1, 1);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (30, 1, 1);
 
 --add bookings with parents associated with families jan 1
 
-INSERT INTO booking (block_id, user_id)
-VALUES (1, 4);
-INSERT INTO booking (block_id, user_id)
-VALUES (2, 4);
-INSERT INTO booking (block_id, user_id)
-VALUES (3, 4);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (1, 4, 2);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (2, 4, 2);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (3, 4, 2);
 
-INSERT INTO booking (block_id, user_id)
-VALUES (1, 5);
-INSERT INTO booking (block_id, user_id)
-VALUES (2, 5);
-INSERT INTO booking (block_id, user_id)
-VALUES (3, 5);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (1, 5, 3);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (2, 5, 3);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (3, 5, 3);
 
-INSERT INTO booking (block_id, user_id)
-VALUES (1, 6);
-INSERT INTO booking (block_id, user_id)
-VALUES (2, 6);
-INSERT INTO booking (block_id, user_id)
-VALUES (3, 6);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (1, 6, 4);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (2, 6, 4);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (3, 6, 4);
 
-INSERT INTO booking (block_id, user_id)
-VALUES (1, 7);
-INSERT INTO booking (block_id, user_id)
-VALUES (2, 7);
-INSERT INTO booking (block_id, user_id)
-VALUES (3, 7);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (1, 7, 4);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (2, 7, 4);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (3, 7, 4);
 
-INSERT INTO booking (block_id, user_id)
-VALUES (1, 8);
-INSERT INTO booking (block_id, user_id)
-VALUES (2, 8);
-INSERT INTO booking (block_id, user_id)
-VALUES (3, 8);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (1, 8, 3);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (2, 8, 3);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (3, 8, 3);
 
 --jan 2
 ----------------------------------------------------------------------------
 
-INSERT INTO booking (block_id, user_id)
-VALUES (4, 4);
-INSERT INTO booking (block_id, user_id)
-VALUES (5, 4);
-INSERT INTO booking (block_id, user_id)
-VALUES (6, 4);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (4, 4, 2);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (5, 4, 2);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (6, 4, 2);
 
-INSERT INTO booking (block_id, user_id)
-VALUES (7, 5);
-INSERT INTO booking (block_id, user_id)
-VALUES (8, 5);
-INSERT INTO booking (block_id, user_id)
-VALUES (9, 5);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (7, 5, 3);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (8, 5, 3);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (9, 5, 3);
 
-INSERT INTO booking (block_id, user_id)
-VALUES (4, 6);
-INSERT INTO booking (block_id, user_id)
-VALUES (6, 6);
-INSERT INTO booking (block_id, user_id)
-VALUES (8, 6);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (4, 6, 4);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (6, 6, 4);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (8, 6, 4);
 
-INSERT INTO booking (block_id, user_id)
-VALUES (10, 7);
-INSERT INTO booking (block_id, user_id)
-VALUES (11, 7);
-INSERT INTO booking (block_id, user_id)
-VALUES (12, 7);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (10, 7, 4);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (11, 7, 4);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (12, 7, 4);
 
-INSERT INTO booking (block_id, user_id)
-VALUES (4, 8);
-INSERT INTO booking (block_id, user_id)
-VALUES (12, 8);
-INSERT INTO booking (block_id, user_id)
-VALUES (14, 8);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (4, 8, 3);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (12, 8, 3);
+INSERT INTO booking (block_id, user_id, family_id)
+VALUES (14, 8, 3);

--- a/database/data.sql
+++ b/database/data.sql
@@ -20,7 +20,6 @@ INSERT INTO users (user_role, username, password, first_name, last_name, email, 
 VALUES(1, 'Stevie', 'pass', 'Stevie', 'Samename', 'stevie54@gmail.com', '132-4365');
 INSERT INTO users (user_role, username, password, first_name, last_name, email, phone_number)
 VALUES(1, '1234', '1234', 'Bad', 'Username', 'badusername@gmail.com', '132-4365');
-
 --Adds families with corresponding users
 
 INSERT INTO family (family_name, parent_one, children)
@@ -46,7 +45,7 @@ VALUES('green', 2, 10, '5-214');
 INSERT INTO time_block(block_start, block_end, room_id, modifier, note)
 VALUES('2018-01-01 08:00:00', '2018-01-01 11:00:00', 1, 1, 'morning block!');
 INSERT INTO time_block(block_start, block_end, room_id, modifier, note)
-VALUES('2018-01-01 12:00:00', '2018-01-01 14:00:00', 1, 2, 'noon block!');
+VALUES('2018-01-01 12:00:00', '2018-01-01 14:00:00', 1, 1, 'noon block!');
 INSERT INTO time_block(block_start, block_end, room_id, modifier, note)
 VALUES('2018-01-01 15:00:00', '2018-01-01 17:00:00', 1, 1, 'afternoon block!');
 
@@ -184,3 +183,17 @@ INSERT INTO time_block(block_start, block_end, room_id, modifier, note)
 VALUES('2018-01-26 12:00:00', '2018-02-26 14:00:00', 2, 1, 'noon block!');
 INSERT INTO time_block(block_start, block_end, room_id, modifier, note)
 VALUES('2018-01-26 15:00:00', '2018-02-26 17:00:00', 2, 1, 'afternoon block!');
+
+INSERT INTO time_block(block_start, block_end, room_id, modifier, note)
+VALUES('2018-03-07 08:00:00', '2018-03-07 11:00:00', 2, 1, 'morning block!');
+INSERT INTO time_block(block_start, block_end, room_id, modifier, note)
+VALUES('2018-03-08 12:00:00', '2018-03-08 14:00:00', 2, 1, 'noon block!');
+INSERT INTO time_block(block_start, block_end, room_id, modifier, note)
+VALUES('2018-03-09 15:00:00', '2018-03-09 17:00:00', 2, 1, 'afternoon block!');
+
+INSERT INTO time_block(block_start, block_end, room_id, modifier, note)
+VALUES('2018-03-07 08:00:00', '2018-03-07 11:00:00', 1, 1, 'morning block!');
+INSERT INTO time_block(block_start, block_end, room_id, modifier, note)
+VALUES('2018-03-08 12:00:00', '2018-03-08 14:00:00', 1, 1, 'noon block!');
+INSERT INTO time_block(block_start, block_end, room_id, modifier, note)
+VALUES('2018-03-09 15:00:00', '2018-03-09 17:00:00', 1, 1, 'afternoon block!');

--- a/database/data.sql
+++ b/database/data.sql
@@ -20,6 +20,7 @@ INSERT INTO users (user_role, username, password, first_name, last_name, email, 
 VALUES(1, 'Stevie', 'pass', 'Stevie', 'Samename', 'stevie54@gmail.com', '132-4365');
 INSERT INTO users (user_role, username, password, first_name, last_name, email, phone_number)
 VALUES(1, '1234', '1234', 'Bad', 'Username', 'badusername@gmail.com', '132-4365');
+
 --Adds families with corresponding users
 
 INSERT INTO family (family_name, parent_one, children)

--- a/database/dbinit.sql
+++ b/database/dbinit.sql
@@ -26,7 +26,7 @@ CREATE TABLE family (
     family_name     TEXT,        
     parent_one      INT         REFERENCES users (user_id),
     parent_two      INT         REFERENCES users (user_id),
-    children		INT
+    children		    INT
 );
 
 CREATE TABLE time_block (

--- a/events.go
+++ b/events.go
@@ -248,7 +248,7 @@ func listEvents(r *http.Request) ([]*Event, error) {
 	/* If target given, and target is dash --> only return events for which the user is booked */
 	dest := mux.Vars(r)["target"]
 	if dest == "dash" {
-		evs2 := []*Event{}
+		var evs2 []*Event
 		for _, e := range evs {
 			if e.Booked {
 				evs2 = append(evs2, e) // add to evs2 if booked
@@ -316,7 +316,7 @@ func makeEvents(blocks []TimeBlock) []*Event {
  * Attempts to get long-form, then short-form;
  * upon failure it returns the current datetime and the parsing error
  */
-func parseDate(date string) (time.Time, error) {
+func _(date string) (time.Time, error) {
 	// try parsing long-form
 
 	d, err := time.Parse(isoTimeShort, date)

--- a/events.go
+++ b/events.go
@@ -373,17 +373,17 @@ func (e *Event) setBookingStatus(uid int) (*Event, error) {
 /* Prety coloour plalalalette */
 //noinspection GoUnusedConst,GoUnusedConst,GoUnusedConst
 const (
-	RED       = "#F44336"
-	PINK      = "#E91E63"
-	PURPLE    = "#9C27B0"
-	BLUE      = "#2196F3"
-	DGREEN    = "#4CAF50"
-	LGREEN    = "#76FF03"
-	LIME      = "#AEEA00"
-	YELLOW    = "#FAD201"
-	ORANGE    = "#FF9800"
-	GREY      = "#9E9E9E"
-	BLUE_GREY = "#607D8B"
+	RED      = "#F44336"
+	PINK     = "#E91E63"
+	PURPLE   = "#9C27B0"
+	BLUE     = "#2196F3"
+	DGREEN   = "#4CAF50"
+	LGREEN   = "#76FF03"
+	LIME     = "#AEEA00"
+	YELLOW   = "#FAD201"
+	ORANGE   = "#FF9800"
+	GREY     = "#9E9E9E"
+	BLUEGREY = "#607D8B"
 )
 
 /* CHanges the color code to correspond to the room name of the event */

--- a/page.go
+++ b/page.go
@@ -10,6 +10,7 @@ type Page struct {
 	Username string
 	/* Dependency flags for templates */
 	Calendar bool // page has calendar --> set flag to true
+	Chart bool // page requires chart.js
 }
 
 /*
@@ -44,9 +45,6 @@ func loadPage(pn string, r *http.Request) (*Page, error) {
 		return nil, errors.New("invalid username")
 	}
 	data.Username = uname
-
-	/* Finally, using the data gathered about our page, set the dependency flags */
-	data.setDependencyFlags()
 	return data, nil
 }
 
@@ -70,17 +68,6 @@ func getRoleNum(r *http.Request) (int, error) {
 	return role, nil
 }
 
-/*
- * Reads Page struct and adds the {string:string} needed by templates.
- * e.g. if page requires calendar --> sets Calendar field to true
- */
-func (p *Page) setDependencyFlags() *Page {
-	// Pages which contain calendar
-	if p.PageName == "calendar" || p.PageName == "dashboard" {
-		p.Calendar = true
-	}
-	return p
-}
 
 /* CompareName returns true when PageName == comparator */
 func (p Page) CompareName(comparator string) bool {

--- a/router.go
+++ b/router.go
@@ -114,6 +114,9 @@ func loadDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s := tmpls.Lookup("dashboard.tmpl")
+	// dependency flags for dashboard
+	pg.Calendar = true;
+	pg.Chart = true;
 	s.ExecuteTemplate(w, "dashboard", pg) // include page struct
 }
 
@@ -124,6 +127,8 @@ func loadCalendar(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s := tmpls.Lookup("calendar.tmpl")
+	// calendar dependency flag
+	pg.Calendar = true;
 	logger.Println(pg)
 	logger.Println(s.ExecuteTemplate(w, "calendar", pg))
 }

--- a/router.go
+++ b/router.go
@@ -91,7 +91,7 @@ func apiRoutes(r *mux.Router) {
 	s := r.PathPrefix("/api/v1").Subrouter()
 	s.HandleFunc("/admin/calendar/setup/", calSetup).Methods("POST")
 	s.HandleFunc("/admin/calendar/setup/", undoSetup).Methods("DELETE")
-	s.HandleFunc("/dashboard", dashboardData).Methods("GET")
+	s.HandleFunc("/dashboard", getDashData).Methods("GET")
 
 	/* Events JSON routes for scheduler system */
 	s.HandleFunc("/events/{target}", getEvents).Methods("GET")

--- a/router.go
+++ b/router.go
@@ -115,8 +115,8 @@ func loadDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 	s := tmpls.Lookup("dashboard.tmpl")
 	// dependency flags for dashboard
-	pg.Calendar = true;
-	pg.Chart = true;
+	pg.Calendar = true
+	pg.Chart = true
 	s.ExecuteTemplate(w, "dashboard", pg) // include page struct
 }
 
@@ -128,7 +128,7 @@ func loadCalendar(w http.ResponseWriter, r *http.Request) {
 	}
 	s := tmpls.Lookup("calendar.tmpl")
 	// calendar dependency flag
-	pg.Calendar = true;
+	pg.Calendar = true
 	logger.Println(pg)
 	logger.Println(s.ExecuteTemplate(w, "calendar", pg))
 }

--- a/views/public/css/dashboard.css
+++ b/views/public/css/dashboard.css
@@ -5,25 +5,6 @@
     width: 50%;
     background: black;
 }
-.right-column{
-    float: right;
-    background: grey;
-    right: 0;
-    width: 50%;
-    color: blue;
-}
-.top {
-    top:0
-}
-.left-division {
-    border: solid coral;
-    display: inline-block;
-    width: 49%;
-}
-.hours {
-    font-size: 14vw;
-    text-align: center;
-}
 
 #wdgt-container {
     font-weight: bold;
@@ -50,6 +31,7 @@
 div {
     color: lightblue;
 }
+
 main {
-    background: '#272b30';
+    background-color: '#272b30';
 }

--- a/views/public/css/dashboard.css
+++ b/views/public/css/dashboard.css
@@ -20,14 +20,23 @@
     display: inline-block;
     width: 49%;
 }
-.hours{
+.hours {
     font-size: 14vw;
     text-align: center;
+}
+
+#gauge-container {
+    font-weight: bold;
+    font-family: Calibri, sans-serif;
+    font-size: 4rem;
+    text-align: center;
+    padding: 10px;
+    margin: 10px;
 }
 
 div {
     color: lightblue;
 }
 main {
-    background: black;
+    background: '#272b30';
 }

--- a/views/public/css/dashboard.css
+++ b/views/public/css/dashboard.css
@@ -25,13 +25,26 @@
     text-align: center;
 }
 
-#gauge-container {
+#wdgt-container {
     font-weight: bold;
     font-family: Calibri, sans-serif;
     font-size: 4rem;
     text-align: center;
     padding: 10px;
     margin: 10px;
+    border: 1px solid #5a5a5a;
+    border-radius: 3px;
+}
+
+#hoursChart {
+    border: 1px solid #5a5a5a;
+    border-radius: 3px;
+}
+
+#calendar {
+    padding: 3px;
+    border: 1px solid #5a5a5a;
+    border-radius: 3px;
 }
 
 div {

--- a/views/public/js/calendarFacilitator.js
+++ b/views/public/js/calendarFacilitator.js
@@ -96,5 +96,4 @@ $(document).ready(function() {
         allDaySlot: false,       // shows slot @ top for allday events
         slotDuration: '00:30:00' // hourly divisions
     });
-    $('#calendar').fullCalendar('render');
 });

--- a/views/public/js/dashboard.js
+++ b/views/public/js/dashboard.js
@@ -42,6 +42,7 @@ function requestRemoval(event) {
  */
 function chartInit(elementId, data) {
     let ctx = document.getElementById(elementId).getContext("2d");
+    // noinspection ES6ConvertVarToLetConst
     var hoursChart = new Chart(ctx, {
         type: "line",
         data:
@@ -62,7 +63,14 @@ function chartInit(elementId, data) {
                 ]
             },
         options:{
-            spanGaps: true
+            spanGaps: true,
+            scales: {
+                yAxes: [{
+                    min: 0,
+                    max: 12.5,
+                    stepSize: 1,
+                }]
+            }
         }
     });
 }
@@ -87,8 +95,10 @@ function gaugeInit(elementId, value, goal) {
         highDpiSupport: true,     // High resolution support
     };
 
-    var element = document.getElementById(elementId)
+    // noinspection ES6ConvertVarToLetConst
+    var element = document.getElementById(elementId);
     element.style.zIndex = 1;
+    // noinspection ES6ConvertVarToLetConst
     var gauge = new Gauge(element).setOptions(opts);
     gauge.maxValue = goal;
     gauge.setMinValue(0);
@@ -140,7 +150,8 @@ $(document).ready(function() {
 /* Wait for DOM to load, then get the gauges */
 document.addEventListener("DOMContentLoaded", () => {
         // get values from server
-        var data = {};
+        // noinspection ES6ConvertVarToLetConst
+    var data = {};
         $.ajax({
             url: "/api/v1/dashboard",
             type: 'GET',

--- a/views/public/js/dashboard.js
+++ b/views/public/js/dashboard.js
@@ -114,16 +114,6 @@ function gaugeInit(elementId, value) {
             strokeWidth: 0.00, // The thickness
             color: '#000000' // Fill color
         },
-        fontSize: 24,
-        renderTicks: {
-            divisions: 1,
-            divWidth: 5,
-            divLength: 1,
-            divColor: "#000000",
-            subDivisions: 0,
-            subLength: 0,
-            subWidth: 0,
-        },
         limitMax: true,     // If false, max value increases automatically if value > maxValue
         limitMin: true,     // If true, the min value of the gauge will be fixed
         percentColors: colorRange,
@@ -142,7 +132,7 @@ function gaugeInit(elementId, value) {
     // setup the text
     element = document.getElementById(elementId + "-text");
     element.style.color = gauge.getColorForValue(value);
-    element.innerHTML = value;
+    element.innerHTML = "<h3>" + value + "h</h3>";
     return gauge; // return for use
 }
 
@@ -164,7 +154,9 @@ $(document).ready(function() {
         themeSystem: "bootstrap3",
         editable: false,                 // Need to use templating engine to change bool based on user's rolego ,
         eventRender: function(event, element, view) {
-            element.find('.fc-list-item-title').append("  " + event.bookingCount + "/3");
+            element.find('.fc-list-item-title').append("  " + event.bookingCount + "/3    "
+                + "<span class='glyphicon glyphicon-pushpin' " +
+                        "aria-valuetext='You are booked in this block!'></span><br/>");
         },
         // DOM-Event handling for Calendar Eventblocks (why do js people suck at naming)
         eventOverlap: false,
@@ -186,6 +178,7 @@ document.addEventListener("DOMContentLoaded", () => {
         gaugeInit("hoursDone", 2); // replace literal value (2, 5) with value from server/calculated values
         gaugeInit("hoursBooked", 5);
         chartInit("hoursChart", "");
+        // adjust calendar heading
         load();
     });
 

--- a/views/public/js/dashboard.js
+++ b/views/public/js/dashboard.js
@@ -1,4 +1,12 @@
-function load() {    
+const colorRange = [
+    [0.0, "#AA0000" ],
+    [0.25, "#FF5500"],
+    [0.5, "#FF9A00"],
+    [0.75, "#FAD201"],
+    [1.0, "#00AA00"]
+];
+
+function load() {
     let req = new XMLHttpRequest();
     req.addEventListener("load", function(evt) {
 	    let data = JSON.parse(req.response);
@@ -63,6 +71,81 @@ function requestRemoval(event) {
         }
     });
 }
+
+/*
+ * Spawns our chart (hours vs. time)
+ */
+function chartInit(elementId, data) {
+    let ctx = document.getElementById(elementId).getContext("2d");
+    var hoursChart = new Chart(ctx, {
+        type: "line",
+        data:
+            {
+                labels:
+                    [
+                        "January", "February", "March", "April", "May","June","July"
+                    ],
+            datasets:
+                [
+                    {
+                        label:"Hours/Week",
+                        data:[65,59,80,81,56,55,40],
+                        fill:false,
+                        borderColor:"rgb(75, 192, 192)",
+                        lineTension:0.15
+                    }
+                ]
+            },
+        options:{
+            spanGaps: true
+        }
+    });
+}
+
+// Where elementID is the div to use and value is the number of hours in our case
+// colorRange is an array format [[0.00, "color"], ...[1.0, "#color"]]
+function gaugeInit(elementId, value) {
+    const opts = {
+        angle: -0.35, // The span of the gauge arc
+        lineWidth: 0.11, // The line thickness
+        radiusScale: 1, // Relative radius
+        pointer: {
+            length: 0.0, // // Relative to gauge radius
+            strokeWidth: 0.00, // The thickness
+            color: '#000000' // Fill color
+        },
+        fontSize: 24,
+        renderTicks: {
+            divisions: 1,
+            divWidth: 5,
+            divLength: 1,
+            divColor: "#000000",
+            subDivisions: 0,
+            subLength: 0,
+            subWidth: 0,
+        },
+        limitMax: true,     // If false, max value increases automatically if value > maxValue
+        limitMin: true,     // If true, the min value of the gauge will be fixed
+        percentColors: colorRange,
+        strokeColor: '#E0E0E0',  // to see which ones work best for you
+        generateGradient: true,
+        highDpiSupport: true,     // High resolution support
+    };
+
+    var element = document.getElementById(elementId)
+    element.style.zIndex = 1;
+    var gauge = new Gauge(element).setOptions(opts);
+    gauge.maxValue = 5;
+    gauge.setMinValue(0);
+    gauge.animationSpeed = 60;
+    gauge.set(value);
+    // setup the text
+    element = document.getElementById(elementId + "-text");
+    element.style.color = gauge.getColorForValue(value);
+    element.innerHTML = value;
+    return gauge; // return for use
+}
+
 // Configures calendar options
 $(document).ready(function() {
     // page is now ready, initialize the calendar...
@@ -81,7 +164,7 @@ $(document).ready(function() {
         themeSystem: "bootstrap3",
         editable: false,                 // Need to use templating engine to change bool based on user's rolego ,
         eventRender: function(event, element, view) {
-            element.find('.fc-list-item-title').append("  " + event.bookingCount + " / 3  ");
+            element.find('.fc-list-item-title').append("  " + event.bookingCount + "/3");
         },
         // DOM-Event handling for Calendar Eventblocks (why do js people suck at naming)
         eventOverlap: false,
@@ -95,7 +178,14 @@ $(document).ready(function() {
             end: '18:00'
         }
     });
-    $('#calendar').fullCalendar('render');
 });
 
-load();
+/* Wait for DOM to load, then get the gauges */
+document.addEventListener("DOMContentLoaded", () => {
+        // get values from server
+        gaugeInit("hoursDone", 2); // replace literal value (2, 5) with value from server/calculated values
+        gaugeInit("hoursBooked", 5);
+        chartInit("hoursChart", "");
+        load();
+    });
+

--- a/views/templates/dashboard.tmpl
+++ b/views/templates/dashboard.tmpl
@@ -5,15 +5,26 @@
 <main>
     <div class="container">
         <div class="col-md-7">
-            <h2>Hours completed</h2>
-            <div id="hoursDone" class="top hours"></div>
+            <label id="gauge-container">Weekly Status</label>
         </div>
         <div class="col-md-7">
-            <h2>Hours booked</h2>
-            <div id="hoursBooked" class="hours"></div>
+            <div id="gauge-container">
+                <h2>Completed</h2>
+                <canvas width="200" height="200" id="hoursDone"></canvas>
+                <div id="hoursDone-text"></div>
+            </div>
+            <div id="gauge-container">
+                <h2>Expected</h2>
+                <canvas width="200" height="200" id="hoursBooked"></canvas>
+                <div id="hoursBooked-text"></div>
+            </div>
         </div>
-        <div class="col-md-5">
-            <h4 class="top">Upcoming events</h4>
+        <div class="col-md-7">
+            <h2>Facilitation History</h2>
+            <canvas width="300" height="150" id="hoursChart"></canvas>
+        </div>
+        <div class="col-md-7">
+            <h2>Upcoming events</h2>
             <div id="calendar"></div>
         </div>
     </div>

--- a/views/templates/dashboard.tmpl
+++ b/views/templates/dashboard.tmpl
@@ -4,28 +4,38 @@
 
 <main>
     <div class="container">
-        <div class="col-md-7">
-            <label id="gauge-container">Weekly Status</label>
-        </div>
-        <div class="col-md-7">
-            <div id="gauge-container">
-                <h2>Completed</h2>
-                <canvas width="200" height="200" id="hoursDone"></canvas>
-                <div id="hoursDone-text"></div>
+        <div class="row">
+            <div class="col-sm-6 pull-left">
+                <h2 style="text-align: center">Activity Tracker</h2>
             </div>
-            <div id="gauge-container">
-                <h2>Expected</h2>
-                <canvas width="200" height="200" id="hoursBooked"></canvas>
-                <div id="hoursBooked-text"></div>
+            <div class="col-sm-6 pull-right">
+                <h2 style="text-align: center">Upcoming Events</h2>
             </div>
         </div>
-        <div class="col-md-7">
-            <h2>Facilitation History</h2>
-            <canvas width="300" height="150" id="hoursChart"></canvas>
-        </div>
-        <div class="col-md-7">
-            <h2>Upcoming events</h2>
-            <div id="calendar"></div>
+        <div class="row">
+            <div class="col-sm-3">
+                <div id="wdgt-container">
+                    <h2>Complete</h2>
+                    <canvas width="200" height="200" id="hoursDone"></canvas>
+                    <div id="hoursDone-text"></div>
+                </div>
+            </div>
+            <div class="col-sm-3">
+                <div id="wdgt-container">
+                    <h2>Booked</h2>
+                    <canvas width="200" height="200" id="hoursBooked"></canvas>
+                    <div id="hoursBooked-text"></div>
+                </div>
+            </div>
+            <div class="col-sm-6 pull-right">
+                <div id="calendar"></div>
+            </div>
+            <div class="col-sm-6 pull-left">
+                <div id="wdgt-container">
+                    <h2>Facilitation History</h2>
+                    <canvas width="300" height="150" id="hoursChart"></canvas>
+                </div>
+            </div>
         </div>
     </div>
 </main>

--- a/views/templates/header.tmpl
+++ b/views/templates/header.tmpl
@@ -21,12 +21,16 @@
             <script type="text/javascript" src='/views/fc/lib/moment.min.js'></script>
             <script type="text/javascript" src='/views/fc/fullcalendar.js'></script>
         {{end}}
+        {{if .Chart }}
+            <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js"></script>
+        {{end}}
         <!--Select javascript based on pagename (and further by role of user) -- given as data to the template -->
         {{if eq .PageName "calendar" }}
             <script type="text/javascript" src='/views/public/js/calendar {{- .Role -}} .js'><%= text/javascript %></script>
         {{else if eq .PageName "dashboard"}}
             <link rel="stylesheet" type="text/css" href="/views/public/css/dashboard.css">
-            <script src="/views/public/js/dashboard.js"></script>
+            <script type="text/javascript" src="http://bernii.github.io/gauge.js/dist/gauge.min.js"></script>
+            <script type="text/javascript" src="/views/public/js/dashboard.js"></script>
         {{end}}
         <script src="/views/public/js/login.js" type="text/javascript"></script>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/views/templates/nav.tmpl
+++ b/views/templates/nav.tmpl
@@ -13,7 +13,7 @@
                     <label style="margin-bottom: 0; height: 34px; margin-top: 6px;color: #000000;">{{.Username}}</label>
                 </div>
                 <div class="col-sm-4">
-                    <button type="button" class="btn btn-default">Logout</button>
+                    <button type="button" class="btn btn-default"><span class="glyphicon glyphicon-log-out"></span></button>
                 </div>
              </div>
         </div>

--- a/views/templates/nav.tmpl
+++ b/views/templates/nav.tmpl
@@ -10,7 +10,7 @@
              <div class="col-sm-4">
                 <br>
                 <div class="col-sm-8 text-right" style="height: 34px;padding-right: 0;">
-                    <label style="margin-bottom: 0; height: 34px; margin-top: 6px;">{{.Username}}</label>
+                    <label style="margin-bottom: 0; height: 34px; margin-top: 6px;color: #000000;">{{.Username}}</label>
                 </div>
                 <div class="col-sm-4">
                     <button type="button" class="btn btn-default">Logout</button>


### PR DESCRIPTION
Gauges are working (for the user_id), need a get familyBlocks in date range function to switch to familyHours

Chart works... on the client side. It is dependent on a good dataset, which it does not have currently.
The dashboard.go function for getting the weeklyHours does not work yet.
--> I think getting the historical hours/week and displaying it would look good.
        (We will probably want this for doing the board stats, and more)

Chart would be cool if it displayed a dataset (line) for each parent? + stackedArea to show total hours over time.

Change sql data to include FIDS in booking, where applicable, also added new blocks for testing the weekly displays.


P.S. Sorry coffeecup